### PR TITLE
Added cgroup support for cpusets

### DIFF
--- a/files/cgroup.conf
+++ b/files/cgroup.conf
@@ -1,0 +1,13 @@
+###
+#
+# Slurm cgroup support configuration file
+#
+# See man slurm.conf and man cgroup.conf for further
+# information on cgroup configuration parameters
+#--
+CgroupAutomount=yes
+CgroupReleaseAgentDir="/etc/slurm/cgroup"
+
+ConstrainCores=yes
+ConstrainRAMSpace=no
+

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -30,6 +30,9 @@
 
   - name: pam.d/slurm
     copy: src=pam_slurm dest=/etc/pam.d/slurm owner=root mode=0644
+
+  - name: cgroup.conf
+    copy: src=cgroup.conf dest=/etc/slurm/cgroup.conf owner=root mode=0644
  
   - name: slurm.conf
     template: src=slurm.conf.j2 dest=/etc/slurm/slurm.conf owner=root mode=0644 backup=yes


### PR DESCRIPTION
Added a cgroup.conf file, without it task/cgroup does nothing.
Restraining memory needs to be tested with centos7, on centos6 it did not work properly.
Currently only restrains cpus.
