### PR TITLE
Slurm uidgid2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,8 +87,11 @@ slurm_log_dir: "/var/log/slurm"
 slurm_tmp_dir: "/opt/slurmdb/tmp/slurmd"
 slurmd_tmp_dir: "{{ slurm_tmp_dir }}"
 slurm_state_dir: "/opt/slurmdb/tmp"
-slurm_uid: "995"
-slurm_gid: "992"
+
+# If the current node is a nis server, make sure the slurm user and
+# group exist
+nis_server: False
+
 ##
 slurm_service_node: "{{ hostvars[groups['slurm_service'][0]]['ansible_hostname']  }}"
 slurm_accounting_storage_host: "{{ slurm_service_node }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,6 +69,9 @@ slurm_munge_key_to_nfs: True
 slurm_munge_key_nfs_dir: "/home/{{ admingroup }}"
 slurm_munge_key_nfs: "{{ slurm_munge_key_nfs_dir }}/munge.key"
 #
+# The UID and GID to use when creating the slurm user and group (which
+# is used for running the slurm daemons).
+slurm_user_uid_gid: 681
 
 #####
 fgci_install: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,9 +69,6 @@ slurm_munge_key_to_nfs: True
 slurm_munge_key_nfs_dir: "/home/{{ admingroup }}"
 slurm_munge_key_nfs: "{{ slurm_munge_key_nfs_dir }}/munge.key"
 #
-# The UID and GID to use when creating the slurm user and group (which
-# is used for running the slurm daemons).
-slurm_user_uid_gid: 681
 
 #####
 fgci_install: True

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -36,12 +36,9 @@
  
   - name: slurm.conf
     template: src=slurm.conf.j2 dest=/etc/slurm/slurm.conf owner=root mode=0644 backup=yes
-
-  - name: add slurm unix group
-    group: name=slurm gid={{ slurm_user_uid_gid }} system=yes 
    
   - name: add slurm unix user
-    user: name=slurm uid={{ slurm_user_uid_gid }} group=slurm shell=/sbin/nologin createhome=no home=/ system=yes groups=
+    user: name=slurm shell=/sbin/nologin createhome=no home=/nonexixtent system=yes append=yes
 
   - name: write all slurm logs handled by rsyslog to one file
     template: src=slurm_rsyslog.conf dest=/etc/rsyslog.d/10_slurm_rsyslog.conf owner=root mode=0644 backup=yes

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -41,7 +41,7 @@
     group: name=slurm gid={{ slurm_gid }} system=yes state=present
    
   - name: add slurm unix user
-    user: name=slurm shell=/sbin/nologin createhome=no home=/nonexixtent system=yes append=yes uid={{ slurm_uid }}
+    user: name=slurm shell=/sbin/nologin createhome=no home=/ system=yes append=yes uid={{ slurm_uid }} group=slurm
 
   - name: write all slurm logs handled by rsyslog to one file
     template: src=slurm_rsyslog.conf dest=/etc/rsyslog.d/10_slurm_rsyslog.conf owner=root mode=0644 backup=yes

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -36,9 +36,12 @@
  
   - name: slurm.conf
     template: src=slurm.conf.j2 dest=/etc/slurm/slurm.conf owner=root mode=0644 backup=yes
+
+  - name: add slurm unix group
+    group: name=slurm gid={{ slurm_user_uid_gid }} system=yes 
    
   - name: add slurm unix user
-    user: name=slurm shell=/sbin/nologin createhome=no home=/nonexixtent system=yes append=yes
+    user: name=slurm uid={{ slurm_user_uid_gid }} group=slurm shell=/sbin/nologin createhome=no home=/ system=yes groups=
 
   - name: write all slurm logs handled by rsyslog to one file
     template: src=slurm_rsyslog.conf dest=/etc/rsyslog.d/10_slurm_rsyslog.conf owner=root mode=0644 backup=yes

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -38,10 +38,12 @@
     template: src=slurm.conf.j2 dest=/etc/slurm/slurm.conf owner=root mode=0644 backup=yes
 
   - name: add slurm unix group
-    group: name=slurm gid={{ slurm_gid }} system=yes state=present
+    group: name=slurm system=yes state=present
+    when: nis_server
    
   - name: add slurm unix user
-    user: name=slurm shell=/sbin/nologin createhome=no home=/ system=yes append=yes uid={{ slurm_uid }} group=slurm
+    user: name=slurm shell=/sbin/nologin createhome=no home=/ system=yes append=yes group=slurm
+    when: nis_server
 
   - name: write all slurm logs handled by rsyslog to one file
     template: src=slurm_rsyslog.conf dest=/etc/rsyslog.d/10_slurm_rsyslog.conf owner=root mode=0644 backup=yes

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -181,12 +181,6 @@
   - name: slurm.conf
     template: src=slurm.conf.j2 dest=/etc/slurm/slurm.conf owner=root mode=0644 backup=yes
 
-  - name: add slurm unix group
-    group: name=slurm gid={{ slurm_gid }} system=yes state=present
-
-  - name: add slurm user
-    user: name=slurm shell=/sbin/nologin createhome=no home=/nonexixtent system=yes append=yes uid="{{ slurm_uid }}"
-
   - name: add slurm log dir
     file: path={{ slurm_log_dir }} state=directory owner=slurm group=slurm mode=0750
 


### PR DESCRIPTION
Make sure that the primary group of the slurm user is the slurm group. And lets set the homedir to /, that's the usual RHEL convention for daemon users that don't have their own home.