### PR TITLE
Use proctrack/cgroup for tracking jobs

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -27,7 +27,7 @@ MpiDefault=none
 MpiParams=ports=12000-12999
 SlurmctldPidFile=/var/run/slurmctld.pid
 SlurmdPidFile=/var/run/slurmd.pid
-ProctrackType=proctrack/linuxproc
+ProctrackType=proctrack/cgroup
 #PluginDir=
 CacheGroups=1
 FirstJobId={{ slurm_first_job_id }}


### PR DESCRIPTION
Using cgroup for process tracking is more reliable than using /proc or PPID, as processes cannot escape from the cgroup.