### PR TITLE
Make slurmdbd log via syslog

### DIFF
--- a/templates/slurmdbd.conf.j2
+++ b/templates/slurmdbd.conf.j2
@@ -21,7 +21,6 @@ SlurmUser=slurm
 #MessageTimeout=300
 DebugLevel=4
 #DefaultQOS=normal,standby
-LogFile=/var/log/slurm/slurmdbd.log
 PidFile=/var/run/slurmdbd.pid
 #PluginDir=/usr/lib/slurm
 #PrivateData=accounts,users,usage,jobs


### PR DESCRIPTION
slurmd's and slurmctld already log via syslog, which is the right thing to do (TM). So lets do it for slurmdbd as well.