### PR TITLE
Allow setting ControlAddr

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -10,7 +10,9 @@
 #
 ClusterName={{ slurm_clustername }}
 ControlMachine={{ slurm_service_node }}
-ControlAddr={{ slurm_service_node }}
+{% if slurm_control_addr is defined %}
+ControlAddr={{ slurm_control_addr }}
+{% endif }
 #BackupController=service02
 #BackupAddr=service02
 #


### PR DESCRIPTION
ControlAddr is useful in case it's a different hostname than the short
name defined in ControlMachine. We need it because our service nodes
have have the same short names on both the external and internal
interface, and by default the login node tries to connect to the
control machine over the external interface which doesn't work due to
the firewall.