### PR TITLE
sysctl settings for slurmctld

### DIFF
--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -124,6 +124,12 @@
   - name: start and enable munge
     service: name=munge state=started enabled=yes
 
+  - name: Increase net.core.somaxconn for slurmctld
+    sysctl: name=net.core.somaxconn value=4096 sysctl_file=/etc/sysctl.d/50-slurm.conf
+
+  - name: Increase net.ipv4.tcp_max_syn_backlog for slurmctld
+    sysctl: name=net.ipv4.tcp_max_syn_backlog value=4096 sysctl_file=/etc/sysctl.d/50-slurm.conf
+
   - name: install Slurm ( state=present - not updating )
     yum: name={{ item }} state=present
     with_items: slurm_packages


### PR DESCRIPTION
Based on the recommendations in the slurm high throughput computing
guide.