### PR TITLE
Ignore errors when starting slurmd, and set state=started

### DIFF
--- a/tasks/compute.yml
+++ b/tasks/compute.yml
@@ -34,9 +34,11 @@
     template: src=namespace_clean.sh.j2 dest=/usr/local/libexec/slurm/epilog.d/namespace_clean.sh owner=root group=root mode=0755
 
   - name: start and enable slurm on EL6
-    service: name=slurm state=restarted enabled=yes
+    service: name=slurm state=started enabled=yes
     when: ansible_distribution_major_version == "6"
+    ignore_errors: yes
 
   - name: start and enable slurmD on EL7
-    service: name=slurmd state=restarted enabled=yes
+    service: name=slurmd state=started enabled=yes
     when: ansible_distribution_major_version == "7"
+    ignore_errors: yes


### PR DESCRIPTION
When installing a new node, ansible-pull-script fails if the node is
not present in slurm.conf, preventing the playbook from
continuing. OTOH, putting the new nodes into slurm.conf before
verifying the they have installed correctly might not be wise either.

Further, set state=started for slurmd instead of restarted, this
prevents bouncing slurmd unnecessarily every time ansible runs.