### PR TITLE
Remove slurm_type

### DIFF
--- a/OPENSTACK.md
+++ b/OPENSTACK.md
@@ -24,12 +24,14 @@ Tested with these linux distributions:
 
 All variables should be defined in defaults/main.yml
 
- - if {{ slurm_type }} in group_vars/group/group.yml is set to:
-  - "compute" the group runs slurmd
-  - "submit" the group run munge
-  - "service" the group runs slurmdbd, slurmctld
+All nodes run munge. Nodes which are part of the slurm\_compute host
+group will additionally run slurmd. Nodes which are part of the
+slurm\_service host group will additionally runs slurmctld and
+slurmdbd.
 
-You also need to add a mysql_slurm_password: "PASSWORD" string somewhere. This will be used to set a password for the slurm mysql user.
+You also need to add a mysql\_slurm\_password: "PASSWORD" string
+somewhere. This will be used to set a password for the slurm mysql
+user.
 
 
 ### Below instructions are for running slurm and perhaps multiple slurm instances in openstack

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ Tested with these linux distributions:
 
 All variables should be defined in defaults/main.yml
 
- - if {{ slurm_type }} in group_vars/group/group.yml is set to:
-  - "compute" the group runs slurmd
-  - "submit" the group run munge
-  - "service" the group runs slurmdbd, slurmctld
+All nodes run munge. Nodes which are part of the slurm\_compute host
+group will additionally run slurmd. Nodes which are part of the
+slurm\_service host group will additionally runs slurmctld and
+slurmdbd.
 
-You also need to add a mysql_slurm_password: "PASSWORD" string somewhere. This will be used to set a password for the slurm mysql user. See http://docs.ansible.com/ansible/playbooks_vault.html
+You also need to add a mysql\_slurm_password: "PASSWORD" string
+somewhere. This will be used to set a password for the slurm mysql
+user. See http://docs.ansible.com/ansible/playbooks_vault.html
 
 To add your own nodes and queues define the slurm_nodelist and slurm_partitionlist lists.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,7 +84,6 @@ slurm_Epilog: "/usr/local/libexec/slurm/epilog.d/*"
 slurm_TaskEpilog: "/usr/bin/epilog"
 slurm_TaskPlugin: "task/cgroup"
 slurm_version: "15.08.3"
-slurm_type: ""
 slurm_build: False
 slurm_log_dir: "/var/log/slurm"
 slurm_logrotate_rotate_interval: "weekly"
@@ -235,7 +234,6 @@ slurm_AccountingStorageTRES: "gres/gpu:teslak80"
 # - # set slurm_mysql_passwords to something. If this variable is not set the role will fail.
 # - slurm_mysql_password: "CHANGEME"
 # - slurm_version is only used when grabbing the source 
-# - slurm_type (service, compute or submit) should be set with group_vars
 # - slurm_control_addr is the same as controlmachine by default. Define it here to change it.
 # - slurm_control_addr: "{{ slurm_service_node }}"
 # - # If you wish to add accounting for additional TRES types, uncomment and edit the following:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 
 
 - include: build.yml
-  when: slurm_build == True and slurm_type == "service" and ansible_os_family == "RedHat"
+  when: "slurm_build == True and 'slurm_service' in group_names and ansible_os_family == 'RedHat'"
 
 - include: common.yml
   when: ansible_os_family == "RedHat"
@@ -22,10 +22,10 @@
   when: (slurm_accounting_storage_host == ansible_hostname) and ansible_os_family == "RedHat"
 
 - include: service.yml
-  when: slurm_type == "service" and ansible_os_family == "RedHat"
+  when: "'slurm_service' in group_names and ansible_os_family == 'RedHat'"
 
 - include: compute.yml
-  when: slurm_type == "compute" and ansible_os_family == "RedHat"
+  when: "'slurm_compute' in group_names and ansible_os_family == 'RedHat'"
 
 - include: submit.yml
-  when: slurm_type == "submit" and ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,7 +6,6 @@
      - ansible-role-pam
      - ansible-role-slurm
    vars:
-     - slurm_type: "notype"
      - slurm_accounting_storage_host: "dbdhost.example.com"
      - slurm_TrackWCKey: "no"
      - slurm_service_node: "install1"


### PR DESCRIPTION
slurm_type is redundant since the "slurm type" is already given by the slurm_compute and slurm_service host groups in the ansible hosts file (those groups are defined in fgci-ansible:/examples/hosts-example so all sites should have them).

This patch also gets rid of the slurm type "submit"; now all nodes that this role is run against become "submit nodes" (i.e. they run munged, and slurm command line tools are available).