### PR TITLE
move the munge tasks for dbd host to service.yml

### DIFF
--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -5,18 +5,6 @@
 
 ####
 
-  - name: get munge key for distribution to nodes
-    copy: src=files/munge.key
-          dest=/etc/munge/munge.key
-          owner=munge
-          group=munge
-          mode=0400
-    notify:
-     - restart munge
-
-  - name: start munge
-    service: name=munge state=started enabled=yes
-
   - name: install slurmdbd specific packages for EL6
     package: "name={{item}} state=present"
     with_items:

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -114,6 +114,22 @@
   - name: start and enable munge
     service: name=munge state=started enabled=yes
 
+  - name: copy in munge key to slurm_accounting_storage_host too if it is different than the service node
+    copy: src=files/munge.key
+          dest=/etc/munge/munge.key
+          owner=munge
+          group=munge
+          mode=0400
+    delegate_to: "{{ slurm_accounting_storage_host }}"
+    when: slurm_accounting_storage_host != ansible_hostname
+    notify:
+     - restart munge
+
+  - name: start and enable munge on the slurm_accouting_storage_host too if it is different than the service node
+    service: name=munge state=started enabled=yes
+    delegate_to: "{{ slurm_accounting_storage_host }}"
+    when: slurm_accounting_storage_host != ansible_hostname
+
   - name: Increase net.core.somaxconn for slurmctld
     sysctl: name=net.core.somaxconn
             value={{ slurm_sysctl_core_somaxconn }}


### PR DESCRIPTION
 - so that they are done after munge.key generation
 - github issue #57 
 - while testing on a setup where the accounting host and the slurmctld are on the same it skips these two tasks. Would be nice if this could also be tested on a setup where they are different before we merge.