### PR TITLE
on EL7 with systemd the init script is still added by the slurm RPM

### DIFF
--- a/tasks/compute.yml
+++ b/tasks/compute.yml
@@ -33,5 +33,9 @@
   - name: Create namespace epilog script
     template: src=namespace_clean.sh.j2 dest=/usr/local/libexec/slurm/epilog.d/namespace_clean.sh owner=root group=root mode=0755
 
+  - name: disable the slurm init script slurm on el7
+    service: name=slurm enabled=no
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+
   - name: start and enable slurmd
     service: name={{ slurmd_service }} state=started enabled=yes

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -145,5 +145,9 @@
     command: "sacctmgr -i add cluster {{ siteName }}"
     when: slurm_clusterlist.stdout.find("{{siteName}}") == -1
 
+  - name: disable the slurm init script slurm on el7
+    service: name=slurm enabled=no
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+
   - name: start and enable slurmctld
     service: name={{ slurmctld_service }} state=started enabled=yes


### PR DESCRIPTION
 - let's disable it and have systemd start slurmd and slurmctld
 - when/if the slurm.spec is adjusted to not install the init script on a system with systemd
 - https://github.com/SchedMD/slurm/blob/master/slurm.spec#L452
 - /etc/init.d/slurmdbd is added by the RPM too but seems systemd takes precedence when the slurmdbd.service is present. 