### PR TITLE
Use the modern standard rsyslog format

### DIFF
--- a/templates/slurm_rsyslog.conf
+++ b/templates/slurm_rsyslog.conf
@@ -1,4 +1,6 @@
 # Managed by ansible
-if $programname contains_i 'slurm' then {
-	/var/log/slurm/slurm.log
+
+if $programname startswith 'slurm' then {
+	/var/log/slurm/slurm.log;RSYSLOG_FileFormat
+	stop
 }


### PR DESCRIPTION
Also, check that the program name starts with slurm, this avoid having
pam_slurm messages in the slurm.log (they belong in the
auth.log/secure/etc.).

Finally, stop processing after this so slurm messages don't get
replicated in other log files.