### PR TITLE
Slurm upgrade 16.08

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ user. See http://docs.ansible.com/ansible/playbooks_vault.html
 
 To add your own nodes and queues define the slurm_nodelist and slurm_partitionlist lists.
 
-It is possible to ru the slurmdbd on a different host than the slurmctld by changing the slurm_accounting_storage_host variable.
+It is possible to run the slurmdbd on a different host than the slurmctld by changing the slurm_accounting_storage_host variable.
 
 ### Implementation
 

--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -44,3 +44,6 @@
     template: src=slurmdbd.conf.j2 dest=/etc/slurm/slurmdbd.conf owner=root mode=0640 backup=yes
     notify:
       - restart slurmdbd
+
+  - name: template in dump-all-databases.sh
+    template: src=dump-all-databases.sh.j2 dest=/usr/local/sbin/dump-all-databases.sh owner=root mode=0750 backup=no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,10 +22,14 @@
 - include: common.yml
   when: ansible_os_family == "RedHat"
 
+  # check which version of slurm is installed
+- include: version.yml
+  when: ansible_os_family == "RedHat"
+
   # upgrade is used to compare slurm version installed and the one ansible wants to install
     # pauses the play on the dbd host
 - include: upgrade.yml
-  when: ansible_os_family == "RedHat" 
+  when: (slurm_accounting_storage_host == ansible_hostname) and ansible_os_family == "RedHat"
 
   # slurmdbd - only applied on the node which is the slurmdbd host (can be different or the same as the slurmctld)
     # we want a slurmdbd up before slurmctld

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,11 @@
 - include: common.yml
   when: ansible_os_family == "RedHat"
 
+  # upgrade is used to compare slurm version installed and the one ansible wants to install
+    # pauses the play on the dbd host
+- include: upgrade.yml
+  when: ansible_os_family == "RedHat" 
+
   # slurmdbd - only applied on the node which is the slurmdbd host (can be different or the same as the slurmctld)
     # we want a slurmdbd up before slurmctld
     # fail if you have not defined slurm_mysql_password

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,15 +15,15 @@
 - include: build.yml
   when: "slurm_build == True and 'slurm_service' in group_names and ansible_os_family == 'RedHat'"
 
+  # check which version of slurm is installed
+- include: version.yml
+  when: ansible_os_family == "RedHat"
+
   # common.yml is applied to all nodes
     # configure pam
     # template in cgroup.conf, gres.conf and slurm.conf
     # set up logrotate and rsyslog
 - include: common.yml
-  when: ansible_os_family == "RedHat"
-
-  # check which version of slurm is installed
-- include: version.yml
   when: ansible_os_family == "RedHat"
 
   # upgrade is used to compare slurm version installed and the one ansible wants to install

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -18,10 +18,10 @@
   - name: print custom facts in verbose mode
     debug: var=item verbosity=1
     with_items:
-     - "{{ reg_slurm_yum_version }}"
+     - "{{ reg_slurm_yum_version['stdout'] }}"
      - "{{ slurm_fact_fgci_slurmrepo_version }}"
-     - "{{ reg_slurm_yum_version_major }}"
+     - "{{ reg_slurm_yum_version_major['stdout'] }}"
 
   - name: Pause if we are upgrading between major slurm versions on the dbd host
     pause: prompt="slurm is set to be upgraded on {{ ansible_hostname }}. This is a manual task. Press ENTER when the manual steps are done."
-    when: (slurm_fact_fgci_slurmrepo_version != reg_slurm_yum_version_major.stdout) and (slurm_accounting_storage_host == ansible_hostname)
+    when: (slurm_fact_fgci_slurmrepo_version != reg_slurm_yum_version_major['stdout']) and (slurm_accounting_storage_host == ansible_hostname)

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -2,28 +2,6 @@
 
 #### Upgrade
 
-  - name: Get version of installed slurm RPM
-    shell: yum list installed slurm | grep slurm | awk '{print $2}' | cut -d'-' -f1
-    register: reg_slurm_yum_version
-    always_run: True
-    changed_when: False
-
-  - name: Get version of installed slurm RPM major version
-    shell: yum list installed slurm | grep slurm | awk '{print $2}' | cut -d'-' -f1|cut -d "." -f1-2|sed -e 's/\.//'
-    register: reg_slurm_yum_version_major
-    always_run: True
-    changed_when: False
-
-  - name: Set fact with contents of fgci_slurmrepo_version with only the numbers
-    set_fact: slurm_fact_fgci_slurmrepo_version="{{ fgci_slurmrepo_version | replace('fgcislurm', '')}}"
-
-  - name: print custom facts in verbose mode
-    debug: var=item verbosity=1
-    with_items:
-     - "{{ reg_slurm_yum_version['stdout'] }}"
-     - "{{ slurm_fact_fgci_slurmrepo_version }}"
-     - "{{ reg_slurm_yum_version_major['stdout'] }}"
-
   - name: Pause if we are upgrading between major slurm versions on the dbd host
     pause: prompt="slurm is set to be upgraded on {{ ansible_hostname }}. This is a manual task. Press ENTER when the manual steps are done."
     when: (slurm_fact_fgci_slurmrepo_version != reg_slurm_yum_version_major['stdout']) and (slurm_accounting_storage_host == ansible_hostname)

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -24,4 +24,4 @@
 
   - name: Pause if we are upgrading between major slurm versions on the dbd host
     pause: prompt="slurm is set to be upgraded on {{ ansible_hostname }}. This is a manual task. Press ENTER when the manual steps are done."
-    when: (slurm_fact_fgci_slurmrepo_version != reg_slurm_yum_version_major) and (slurm_accounting_storage_host == ansible_hostname)
+    when: (slurm_fact_fgci_slurmrepo_version != reg_slurm_yum_version_major.stdout) and (slurm_accounting_storage_host == ansible_hostname)

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -1,0 +1,27 @@
+---
+
+#### Upgrade
+
+  - name: Get version of installed slurm RPM
+    shell: yum list installed slurm | grep slurm | awk '{print $2}' | cut -d'-' -f1
+    register: reg_slurm_yum_version
+    changed_when: False
+
+  - name: Get version of installed slurm RPM major version
+    shell: yum list installed slurm | grep slurm | awk '{print $2}' | cut -d'-' -f1|cut -d "." -f1-2
+    register: reg_slurm_yum_version_major
+    changed_when: False
+
+  - name: Set fact with contents of fgci_slurmrepo_version with only the numbers
+    set_fact: slurm_fact_fgci_slurmrepo_version: "{{ fgci_slurmrepo_version | replace('fgcislurm', '')}}"
+
+  - name: print custom facts in verbose mode
+    debug: var=item verbosity=1
+    with_items:
+     - "{{ reg_slurm_yum_version }}"
+     - "{{ slurm_fact_fgci_slurmrepo_version }}"
+     - "{{ reg_slurm_yum_version_major }}"
+
+  - name: Pause if we are upgrading between major slurm versions on the dbd host
+    pause: prompt="slurm is set to be upgraded on {{ ansible_hostname }}. This is a manual task. Press ENTER when the manual steps are done."
+    when: (slurm_fact_fgci_slurmrepo_version != reg_slurm_yum_version_major) and (slurm_accounting_storage_host == ansible_hostname)

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -5,11 +5,13 @@
   - name: Get version of installed slurm RPM
     shell: yum list installed slurm | grep slurm | awk '{print $2}' | cut -d'-' -f1
     register: reg_slurm_yum_version
+    always_run: True
     changed_when: False
 
   - name: Get version of installed slurm RPM major version
     shell: yum list installed slurm | grep slurm | awk '{print $2}' | cut -d'-' -f1|cut -d "." -f1-2|sed -e 's/\.//'
     register: reg_slurm_yum_version_major
+    always_run: True
     changed_when: False
 
   - name: Set fact with contents of fgci_slurmrepo_version with only the numbers

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -8,7 +8,7 @@
     changed_when: False
 
   - name: Get version of installed slurm RPM major version
-    shell: yum list installed slurm | grep slurm | awk '{print $2}' | cut -d'-' -f1|cut -d "." -f1-2
+    shell: yum list installed slurm | grep slurm | awk '{print $2}' | cut -d'-' -f1|cut -d "." -f1-2|sed -e 's/\.//'
     register: reg_slurm_yum_version_major
     changed_when: False
 

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -4,4 +4,7 @@
 
   - name: Pause if we are upgrading between major slurm versions on the dbd host
     pause: prompt="slurm is set to be upgraded on {{ ansible_hostname }}. This is a manual task. Press ENTER when the manual steps are done."
-    when: (slurm_fact_fgci_slurmrepo_version != reg_slurm_yum_version_major['stdout']) and (slurm_accounting_storage_host == ansible_hostname)
+    when: (slurm_fact_fgci_slurmrepo_version != reg_slurm_yum_version_major['stdout']) and (slurm_accounting_storage_host == ansible_hostname) and (reg_slurm_yum_version_major['stdout'] != "")
+    # if the fgci_slurmrepo variable is not same as the version installed
+    # if we are on the slurm accouting storage host
+    # if the version installed is not ""

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -13,7 +13,7 @@
     changed_when: False
 
   - name: Set fact with contents of fgci_slurmrepo_version with only the numbers
-    set_fact: slurm_fact_fgci_slurmrepo_version: "{{ fgci_slurmrepo_version | replace('fgcislurm', '')}}"
+    set_fact: slurm_fact_fgci_slurmrepo_version="{{ fgci_slurmrepo_version | replace('fgcislurm', '')}}"
 
   - name: print custom facts in verbose mode
     debug: var=item verbosity=1

--- a/tasks/version.yml
+++ b/tasks/version.yml
@@ -1,0 +1,25 @@
+---
+
+#### Version
+
+  - name: Get version of installed slurm RPM
+    shell: yum list installed slurm | grep slurm | awk '{print $2}' | cut -d'-' -f1
+    register: reg_slurm_yum_version
+    always_run: True
+    changed_when: False
+
+  - name: Get version of installed slurm RPM major version
+    shell: yum list installed slurm | grep slurm | awk '{print $2}' | cut -d'-' -f1|cut -d "." -f1-2|sed -e 's/\.//'
+    register: reg_slurm_yum_version_major
+    always_run: True
+    changed_when: False
+
+  - name: Set fact with contents of fgci_slurmrepo_version with only the numbers
+    set_fact: slurm_fact_fgci_slurmrepo_version="{{ fgci_slurmrepo_version | replace('fgcislurm', '')}}"
+
+  - name: print custom facts in verbose mode
+    debug: var=item verbosity=1
+    with_items:
+     - "{{ reg_slurm_yum_version['stdout'] }}"
+     - "{{ slurm_fact_fgci_slurmrepo_version }}"
+     - "{{ reg_slurm_yum_version_major['stdout'] }}"

--- a/templates/dump-all-databases.sh.j2
+++ b/templates/dump-all-databases.sh.j2
@@ -1,0 +1,66 @@
+#!/bin/bash
+# {{ ansible_managed }}
+# Daniel Verner 
+# CarrotPlant LLC
+# 2011
+# Backup each mysql databases into a different file, rather than one big file
+# Optionally files can be gzipped (dbname.gz)
+#
+# Usage: dump_all_databases [ -u username -o output_dir -z ]
+#		 
+#	-u username to connect mysql server
+#	-o [output_dir] optional the output directory where to put the files
+#	-z gzip enabled
+#
+# Note: The script will prompt for a password, you cannot specify it as command line argument for security reasons
+#
+# based on the solution from: sonia 16-nov-05 (http://soniahamilton.wordpress.com/2005/11/16/backup-multiple-databases-into-separate-files/)
+
+
+PROG_NAME=$(basename $0)
+USER=""
+PASSWORD=""
+OUTPUTDIR=${PWD}
+GZIP_ENABLED=0
+GZIP=""
+
+MYSQLDUMP="/usr/bin/mysqldump"
+MYSQL="/usr/bin/mysql"
+
+while getopts u:o:z OPTION
+do
+    case ${OPTION} in
+        u) USER=${OPTARG};;
+        o) OUTPUTDIR=${OPTARG};;
+        z) GZIP_ENABLED=1;;
+        ?) echo "Usage: ${PROG_NAME} [ -u username -o output_dir -z ]"
+           exit 2;;
+    esac
+done
+
+if [ "$USER" != '' ]; then
+
+echo "Enter password for" $USER":"
+oldmodes=`stty -g`
+stty -echo
+read PASSWORD
+stty $oldmodes
+
+fi
+
+if [ ! -d "$OUTPUTDIR" ]; then
+    mkdir -p $OUTPUTDIR
+fi
+
+# get a list of databases
+databases=`$MYSQL --user=$USER --password=$PASSWORD -e "SHOW DATABASES;" | grep -Ev "(Database|information_schema)"`
+
+# dump each database in turn
+for db in $databases; do
+    echo $db
+	if [ $GZIP_ENABLED == 1 ]; then
+		$MYSQLDUMP --no-autocommit --skip-extended-insert --single-transaction --force --opt --user=$USER --password=$PASSWORD --databases $db | gzip > "$OUTPUTDIR/$db.gz"
+	else
+	    $MYSQLDUMP --no-autocommit --skip-extended-insert --single-transaction --force --opt --user=$USER --password=$PASSWORD --databases $db > "$OUTPUTDIR/$db.sql"
+   	fi    
+done


### PR DESCRIPTION
With this update the slurm role will pause ( only ) on the slurmdbd host if the slurm version in 
<pre>
yum list installed slurm | grep slurm | awk '{print $2}' | cut -d'-' -f1|cut -d "." -f1-2|sed -e 's/\.//'
</pre>

and 

<pre>
{{ fgci_slurmrepo_version | replace('fgcislurm', '')}}
</pre>

are different (and if the first is not an empty string)

Some comments on this would be nice. What do you think @jabl  and @A1ve5 ?

Should we add notes in ansible for where users should look for documentation? FGI/FGCI confluence is not ideal as that's behind HAKA authentication

I mentioned in #63 that the cgroup variable default has changed. Fortunately we have already the new default set in this role, so we don't need to make SLURM version dependent variable files.