### PR TITLE
Root db access

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,8 @@ admingroup: "admin"
 # Overwrite DB_root_password in your vars file if you want to 
 # use a different password for root and slurm user
 DB_root_password: "{{ slurm_mysql_password }}"
+# Disable mysql security tasks by setting slurm_manage_mysql_security to False
+slurm_manage_mysql_security: True
 
 # If the current node is a nis server, make sure the slurm user and
 # group exist

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,10 @@ slurm_service_packages:
 
 admingroup: "admin"
 
+# Overwrite DB_root_password in your vars file if you want to 
+# use a different password for root and slurm user
+DB_root_password: "{{ slurm_mysql_password }}"
+
 # If the current node is a nis server, make sure the slurm user and
 # group exist
 nis_server: False

--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -22,24 +22,41 @@
   - name: wait for mysql in port 3306 to start
     wait_for: port=3306 delay=10 timeout=60
 
-  - name: delete anonymous sql server user for localhost
-    mysql_user: user="" state=absent login_password="{{ DB_root_password }}"
-
-  - name: set the sql root user passwords
-    mysql_user: user="root" password="{{ DB_root_password }}" host="{{ item }}"
-    with_items:
+  - name: Set root sql user password
+    # If .my.cnf already exists, this will cause an mysql-root-password update.
+    # check_implicit_admin means it tries without password first
+    mysql_user:
+      name: root
+      password: "{{ DB_root_password}}"
+      check_implicit_admin: true
+      host="{{ item }}"
+   with_items:
       - "::1"
       - "127.0.0.1"
       - "localhost"
+    
+  - name: template .my.cnf
+    template:
+     src: "client.my.cnf.j2"
+     dest: "/root/.my.cnf"
+     owner: root
+     group: root
+     mode: 0600
+
+  - name: delete anonymous sql server user for localhost
+    mysql_user: user="" state=absent
 
   - name: remove the mysql test database
-    mysql_db: db=test state=absent login_password="{{ DB_root_password }}"
+    mysql_db: db=test state=absent
 
   - name: create slurm acct db
-    mysql_db: name=slurm_acct_db state=present login_password="{{ DB_root_password }}"
+    mysql_db: name=slurm_acct_db state=present
 
   - name: create slurm sql user
-    mysql_user: name=slurm state=present password="{{ slurm_mysql_password }}" login_password="{{ DB_root_password }}"
+    mysql_user: 
+     name: slurm 
+     state: present 
+     password: "{{ slurm_mysql_password }}"
     register: mysqlslurmuser
     ignore_errors: yes
     tags: debug
@@ -50,11 +67,21 @@
     changed_when: False
 
   - name: ensure slurm sql user has a password and privileges if it does not exist or if it was just added
-    mysql_user: "name=slurm password={{ slurm_mysql_password }} priv=slurm_acct_db.*:ALL state=present update_password=always login_password={{ DB_root_password }}"
+    mysql_user: 
+     name: slurm
+     password: "{{ slurm_mysql_password }}"
+     priv: "slurm_acct_db.*:ALL"
+     state: present 
+     update_password: always
     when: mysqlslurmuser|failed or mysqlslurmuser|changed
 
   - name: template in slurmdbd.conf
-    template: src=slurmdbd.conf.j2 dest=/etc/slurm/slurmdbd.conf owner=root mode=0640 backup=yes
+    template: 
+     src: slurmdbd.conf.j2 
+     dest: /etc/slurm/slurmdbd.conf 
+     owner: root 
+     mode: 0640 
+     backup: yes
     notify:
       - restart slurmdbd
 

--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -38,7 +38,7 @@
     
   - name: template .my.cnf
     template:
-     src: "client.my.cnf.j2"
+     src: ".my.cnf.j2"
      dest: "/root/.my.cnf"
      owner: root
      group: root

--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -11,30 +11,6 @@
     with_items: "{{ slurmdbd_packages }}"
     when: ansible_os_family == "RedHat"
 
-  - name: set the sql root password
-    mysql_user: user=root password={{ DB_root_password }} host=localhost
-    when: ansible_os_family == "RedHat"
-
-  - name: delete anonymous sql server user for localhost
-    mysql_user: user="" state=absent
-    when: ansible_os_family == "RedHat"
-
-  - name: secure the sql root user for ipv6 localhost (::1)
-    mysql_user: user="root" password="{{ DB_root_password }}" host="::1"
-    when: ansible_os_family == "RedHat"
-
-  - name: secure the sql root user for ipv4 localhost (127.0.0.1)
-    mysql_user: user="root" password="{{ DB_root_password }}" host="127.0.0.1"
-    when: ansible_os_family == "RedHat"
-
-  - name: secure the sql root user for localhost domain (localhost)
-    mysql_user: user="root" password="{{ DB_root_password }}" host="localhost"
-    when: ansible_os_family == "RedHat"
-
-  - name: remove the mysql test database
-    mysql_db: db=test state=absent
-    when: ansible_os_family == "RedHat"
-
   - name: start and enable mariadb/mysql
     service: name={{ slurm_sql_service }} state=started enabled=yes
     when: ansible_os_family == "RedHat"
@@ -45,6 +21,19 @@
 
   - name: wait for mysql in port 3306 to start
     wait_for: port=3306 delay=10 timeout=60
+
+  - name: delete anonymous sql server user for localhost
+    mysql_user: user="" state=absent
+
+  - name: set the sql root user
+    mysql_user: user="root" password="{{ DB_root_password }}" host="{{ item }}"
+    with_items:
+      - "::1"
+      - "127.0.0.1"
+      - "localhost"
+
+  - name: remove the mysql test database
+    mysql_db: db=test state=absent
 
   - name: create slurm acct db
     mysql_db: name=slurm_acct_db state=present

--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -23,7 +23,7 @@
     wait_for: port=3306 delay=10 timeout=60
 
   - name: delete anonymous sql server user for localhost
-    mysql_user: user="" state=absent
+    mysql_user: user="" state=absent login_password="{{ DB_root_password }}"
 
   - name: set the sql root user passwords
     mysql_user: user="root" password="{{ DB_root_password }}" host="{{ item }}"

--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -30,10 +30,11 @@
       password: "{{ DB_root_password}}"
       check_implicit_admin: true
       host="{{ item }}"
-   with_items:
-      - "::1"
-      - "127.0.0.1"
-      - "localhost"
+    with_items:
+       - "::1"
+       - "127.0.0.1"
+       - "localhost"
+    when: slurm_manage_mysql_security
     
   - name: template .my.cnf
     template:
@@ -42,15 +43,19 @@
      owner: root
      group: root
      mode: 0600
+    when: slurm_manage_mysql_security
 
   - name: delete anonymous sql server user for localhost
     mysql_user: user="" state=absent
+    when: slurm_manage_mysql_security
 
   - name: remove the mysql test database
     mysql_db: db=test state=absent
+    when: slurm_manage_mysql_security
 
   - name: create slurm acct db
     mysql_db: name=slurm_acct_db state=present
+    when: slurm_manage_mysql_security
 
   - name: create slurm sql user
     mysql_user: 

--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -11,6 +11,30 @@
     with_items: "{{ slurmdbd_packages }}"
     when: ansible_os_family == "RedHat"
 
+  - name: set the sql root password
+    mysql_user: user=root password={{ DB_root_password }} host=localhost
+    when: ansible_os_family == "RedHat"
+
+  - name: delete anonymous sql server user for localhost
+    mysql_user: user="" state=absent
+    when: ansible_os_family == "RedHat"
+
+  - name: secure the sql root user for ipv6 localhost (::1)
+    mysql_user: user="root" password="{{ DB_root_password }}" host="::1"
+    when: ansible_os_family == "RedHat"
+
+  - name: secure the sql root user for ipv4 localhost (127.0.0.1)
+    mysql_user: user="root" password="{{ DB_root_password }}" host="127.0.0.1"
+    when: ansible_os_family == "RedHat"
+
+  - name: secure the sql root user for localhost domain (localhost)
+    mysql_user: user="root" password="{{ DB_root_password }}" host="localhost"
+    when: ansible_os_family == "RedHat"
+
+  - name: remove the mysql test database
+    mysql_db: db=test state=absent
+    when: ansible_os_family == "RedHat"
+
   - name: start and enable mariadb/mysql
     service: name={{ slurm_sql_service }} state=started enabled=yes
     when: ansible_os_family == "RedHat"

--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -39,7 +39,7 @@
     mysql_db: name=slurm_acct_db state=present login_password="{{ DB_root_password }}"
 
   - name: create slurm sql user
-    mysql_user: name=slurm state=present password="{{ DB_root_password }}"
+    mysql_user: name=slurm state=present password="{{ slurm_mysql_password }}" login_password="{{ DB_root_password }}"
     register: mysqlslurmuser
     ignore_errors: yes
     tags: debug
@@ -50,7 +50,7 @@
     changed_when: False
 
   - name: ensure slurm sql user has a password and privileges if it does not exist or if it was just added
-    mysql_user: "name=slurm password={{ slurm_mysql_password }} priv=slurm_acct_db.*:ALL state=present update_password=always"
+    mysql_user: "name=slurm password={{ slurm_mysql_password }} priv=slurm_acct_db.*:ALL state=present update_password=always login_password={{ DB_root_password }}"
     when: mysqlslurmuser|failed or mysqlslurmuser|changed
 
   - name: template in slurmdbd.conf

--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -29,7 +29,7 @@
       name: root
       password: "{{ DB_root_password}}"
       check_implicit_admin: true
-      host="{{ item }}"
+      host: "{{ item }}"
     with_items:
        - "::1"
        - "127.0.0.1"

--- a/tasks/dbd.yml
+++ b/tasks/dbd.yml
@@ -25,7 +25,7 @@
   - name: delete anonymous sql server user for localhost
     mysql_user: user="" state=absent
 
-  - name: set the sql root user
+  - name: set the sql root user passwords
     mysql_user: user="root" password="{{ DB_root_password }}" host="{{ item }}"
     with_items:
       - "::1"
@@ -33,13 +33,13 @@
       - "localhost"
 
   - name: remove the mysql test database
-    mysql_db: db=test state=absent
+    mysql_db: db=test state=absent login_password="{{ DB_root_password }}"
 
   - name: create slurm acct db
-    mysql_db: name=slurm_acct_db state=present
+    mysql_db: name=slurm_acct_db state=present login_password="{{ DB_root_password }}"
 
   - name: create slurm sql user
-    mysql_user: "name=slurm state=present"
+    mysql_user: name=slurm state=present password="{{ DB_root_password }}"
     register: mysqlslurmuser
     ignore_errors: yes
     tags: debug

--- a/templates/.my.cnf.j2
+++ b/templates/.my.cnf.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+[client]
+user=root
+password={{ DB_root_password }}


### PR DESCRIPTION
Configure a mysql root user.
It is possible to disable it by setting a variable: slurm_manage_mysql_security to False
I would like another eye on this before merging and testing in our test cluster.
Based on travis testing it seems to work when installing from scratch, maybe there are some caveats for when doing it on a running system?
