### PR TITLE
Don't stop processing message after outputting to local slurm log.

### DIFF
--- a/templates/slurm_rsyslog.conf
+++ b/templates/slurm_rsyslog.conf
@@ -2,5 +2,4 @@
 
 if $programname startswith 'slurm' then {
 	/var/log/slurm/slurm.log;RSYSLOG_FileFormat
-	stop
 }


### PR DESCRIPTION
Otherwise, stopping here prevents sending the log message to a central
log server.