### PR TITLE
Allow running a backup slurmctld - attempt 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ To add your own nodes and queues define the slurm_nodelist and slurm_partitionli
 
 It is possible to run the slurmdbd on a different host than the slurmctld by changing the slurm_accounting_storage_host variable.
 
+It is also possible to setup a backup slurm controller by defining slurm_backup_controller variable.
+
 SLURM 16.05 can be gotten from the FGCI yum repo by setting:
 <pre>
 fgci_slurmrepo_version: "fgcislurm1605"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,6 +83,10 @@ slurm_mpi_default: "none"
 slurm_mpi_params: "ports=12000-12999"
 slurm_proctrack_type: "proctrack/cgroup"
 slurm_service_node: "{{ hostvars[groups['slurm_service'][0]]['ansible_hostname']  }}"
+# If you want a backup slurmctld, set this variable.
+#slurm_backup_controller: "{{ hostvars[groups['slurm_service'][1]]['ansible_hostname']  }}"
+# The addr of the backup controller, if necessary
+#slurm_backup_addr: "foo.example.com"
 slurm_accounting_storage_host: "{{ slurm_service_node }}"
 slurm_accounting_storage_type: "accounting_storage/slurmdbd"
 slurm_accounting_storage_loc: "slurm_acct_db"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,16 @@
   when: (slurm_accounting_storage_host == ansible_hostname) and ansible_os_family == "RedHat"
   static: no
 
+  # slurmdbd - only applied on the node which is the slurmdbd host (can be different or the same as the slurmctld)
+    # we want a slurmdbd up before slurmctld
+    # fail if you have not defined slurm_mysql_password
+    # fetche munge.key from files/munge.key in the directory where you run ansible
+    # create slurm sql database and users
+    # template in slurmdbd.conf
+     # If there is a change to slurmdbd.conf it will restart slurmdbd with a handler (end of play)
+- include: dbd.yml
+  when: (slurm_accounting_storage_host == ansible_hostname) and ansible_os_family == "RedHat"
+
   # General service tasks:
     # munge:
       # Creates munge.key if /etc/munge/munge.key does not exist
@@ -40,17 +50,7 @@
     # start and enable slurmdbd wherever that runs (after we ensure there's a slurm user/group)
     # sacctmgr create cluster
 - include: service.yml
-  when: "slurm_service_node == ansible_hostname"
-
-  # slurmdbd - only applied on the node which is the slurmdbd host (can be different or the same as the slurmctld)
-    # we want a slurmdbd up before slurmctld
-    # fail if you have not defined slurm_mysql_password
-    # fetche munge.key from files/munge.key in the directory where you run ansible
-    # create slurm sql database and users
-    # template in slurmdbd.conf
-     # If there is a change to slurmdbd.conf it will restart slurmdbd with a handler (end of play)
-- include: dbd.yml
-  when: (slurm_accounting_storage_host == ansible_hostname) and ansible_os_family == "RedHat"
+  when: slurm_service_node == ansible_hostname
 
   # slurmctld hosts, primary and potentially backup
 - include: slurmctld.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,17 +29,7 @@
   when: (slurm_accounting_storage_host == ansible_hostname) and ansible_os_family == "RedHat"
   static: no
 
-  # slurmdbd - only applied on the node which is the slurmdbd host (can be different or the same as the slurmctld)
-    # we want a slurmdbd up before slurmctld
-    # fail if you have not defined slurm_mysql_password
-    # fetche munge.key from files/munge.key in the directory where you run ansible
-    # create slurm sql database and users
-    # template in slurmdbd.conf
-     # If there is a change to slurmdbd.conf it will restart slurmdbd with a handler (end of play)
-- include: dbd.yml
-  when: (slurm_accounting_storage_host == ansible_hostname) and ansible_os_family == "RedHat"
-
-  # slurmctld:
+  # General service tasks:
     # munge:
       # Creates munge.key if /etc/munge/munge.key does not exist
       # Stores munge.key in files/munge.key in the directory where you run ansible
@@ -50,7 +40,21 @@
     # start and enable slurmdbd wherever that runs (after we ensure there's a slurm user/group)
     # sacctmgr create cluster
 - include: service.yml
-  when: "'slurm_service' in group_names and ansible_os_family == 'RedHat'"
+  when: "slurm_service_node == ansible_hostname"
+
+  # slurmdbd - only applied on the node which is the slurmdbd host (can be different or the same as the slurmctld)
+    # we want a slurmdbd up before slurmctld
+    # fail if you have not defined slurm_mysql_password
+    # fetche munge.key from files/munge.key in the directory where you run ansible
+    # create slurm sql database and users
+    # template in slurmdbd.conf
+     # If there is a change to slurmdbd.conf it will restart slurmdbd with a handler (end of play)
+- include: dbd.yml
+  when: (slurm_accounting_storage_host == ansible_hostname) and ansible_os_family == "RedHat"
+
+  # slurmctld hosts, primary and potentially backup
+- include: slurmctld.yml
+  when: slurm_service_node == ansible_hostname or slurm_backup_controller == ansible_hostname
 
   # computes
     # get munge.key from the directory where you run ansible or NFS

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -85,14 +85,3 @@
   - name: start and enable slurmdbd
     service: name=slurmdbd state=started enabled=yes
     when: slurm_accounting_storage_host == ansible_hostname
-
-  - name: sacctmgr show cluster siteName and store in slurm_clusterlist variable
-    command: "sacctmgr -n show cluster {{ siteName }}"
-    register: slurm_clusterlist
-    check_mode: no
-    changed_when: False
-
-  - name: add cluster to accounting
-    command: "sacctmgr -i add cluster {{ siteName }}"
-    when: slurm_clusterlist.stdout.find("{{siteName}}") == -1
-

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -75,21 +75,6 @@
     delegate_to: "{{ slurm_accounting_storage_host }}"
     when: slurm_accounting_storage_host != ansible_hostname
 
-  - name: Increase net.core.somaxconn for slurmctld
-    sysctl: name=net.core.somaxconn
-            value={{ slurm_sysctl_core_somaxconn }}
-            sysctl_file=/etc/sysctl.d/50-slurm.conf
-    when: slurm_manage_sysctl
-
-  - name: Increase net.ipv4.tcp_max_syn_backlog for slurmctld
-    sysctl: name=net.ipv4.tcp_max_syn_backlog
-            value={{ slurm_sysctl_tcp_max_syn_backlog }}
-            sysctl_file=/etc/sysctl.d/50-slurm.conf
-    when: slurm_manage_sysctl
-
-  - name: install Slurm ( state=present - not updating )
-    package: name={{ item }} state=present
-    with_items: "{{ slurm_packages }}"
 
     # slurmdbd needs to be started after the slurm unix user is created
   - name: start and enable slurmdbd on slurm_accounting_storage_host
@@ -111,18 +96,3 @@
     command: "sacctmgr -i add cluster {{ siteName }}"
     when: slurm_clusterlist.stdout.find("{{siteName}}") == -1
 
-  - name: disable the slurm init script slurm on el7
-    service: name=slurm enabled=no
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
-
-  - name: create systemd override directories for slurmctld
-    file: path="/etc/systemd/system/slurmctld.service.d" state=directory owner=root mode=0755
-    when: slurm_systemd_override_slurmctld and ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
-
-  - name: template in systemd override file for slurmctld
-    template: src=systemd_override.conf.j2 dest=/etc/systemd/system/slurmctld.service.d/slurmctld_override.conf backup=no owner=root mode=0644
-    when: slurm_systemd_override_slurmctld and ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
-
-
-  - name: start and enable slurmctld
-    service: name={{ slurmctld_service }} state=started enabled=yes

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -42,3 +42,14 @@
   - name: start and enable slurmctld
     service: name={{ slurmctld_service }} state=started enabled=yes
     when: slurm_service_node == ansible_hostname or slurm_backup_controller == ansible_hostname
+
+  - name: sacctmgr show cluster siteName and store in slurm_clusterlist variable
+    command: "sacctmgr -n show cluster {{ siteName }}"
+    register: slurm_clusterlist
+    check_mode: no
+    changed_when: False
+
+  - name: add cluster to accounting
+    command: "sacctmgr -i add cluster {{ siteName }}"
+    when: slurm_clusterlist.stdout.find("{{siteName}}") == -1
+

--- a/tasks/slurmctld.yml
+++ b/tasks/slurmctld.yml
@@ -1,0 +1,44 @@
+---
+  - name: install slurm service specific packages
+    package: "name={{ item }} state=present"
+    with_items: "{{ slurm_service_packages }}"
+
+  - name: Install munge key for slurmctld
+    copy:
+      src=files/munge.key
+      dest=/etc/munge/munge.key
+      owner=munge
+      group=munge
+      mode=0400
+    notify: restart munge
+
+  - name: start and enable munge
+    service: name=munge state=started enabled=yes
+
+  - name: Increase net.core.somaxconn for slurmctld
+    sysctl: name=net.core.somaxconn
+            value={{ slurm_sysctl_core_somaxconn }}
+            sysctl_file=/etc/sysctl.d/50-slurm.conf
+    when: slurm_manage_sysctl
+
+  - name: Increase net.ipv4.tcp_max_syn_backlog for slurmctld
+    sysctl: name=net.ipv4.tcp_max_syn_backlog
+            value={{ slurm_sysctl_tcp_max_syn_backlog }}
+            sysctl_file=/etc/sysctl.d/50-slurm.conf
+    when: slurm_manage_sysctl
+
+  - name: disable the slurm init script slurm on el7
+    service: name=slurm enabled=no
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+
+  - name: create systemd override directories for slurmctld
+    file: path="/etc/systemd/system/slurmctld.service.d" state=directory owner=root mode=0755
+    when: slurm_systemd_override_slurmctld and ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+
+  - name: template in systemd override file for slurmctld
+    template: src=systemd_override.conf.j2 dest=/etc/systemd/system/slurmctld.service.d/slurmctld_override.conf backup=no owner=root mode=0644
+    when: slurm_systemd_override_slurmctld and ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
+
+  - name: start and enable slurmctld
+    service: name={{ slurmctld_service }} state=started enabled=yes
+    when: slurm_service_node == ansible_hostname or slurm_backup_controller == ansible_hostname

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -13,6 +13,12 @@ ControlMachine={{ slurm_service_node }}
 {% if slurm_control_addr is defined %}
 ControlAddr={{ slurm_control_addr }}
 {% endif %}
+{% if slurm_backup_controller is defined %}
+BackupController={{ slurm_backup_controller }}
+{% endif %}
+{% if slurm_backup_addr is defined %}
+BackupAddr={{ slurm_backup_addr }}
+{% endif %}
 SlurmUser={{ slurm_SlurmUser }}
 SlurmctldPort={{ slurm_SlurmctldPort }}
 SlurmdPort={{ slurm_SlurmdPort }}


### PR DESCRIPTION
This PR takes the changes from #75 and instead:

 - dbd.yml is again before service.yml (is there a reason why you moved it after service.yml?)
 - the sacctmgr "create cluster" command is after slurmctld is started in slurmctld.yml

Summary of changes:
 - new variables: {{ slurm_backup_controller }} and {{ slurm_backup_addr }} which are undefined by default.
 - some tasks moved out of service.yml into slurmctld.yml