### PR TITLE
Send a slurm efficiency report if the user requests mail notification

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ slurm_packages:
  - slurm-torque
  - slurm-munge
  - slurm-sjobexit
+ - slurm-seff
 # - slurm-spank-x11
 #
 

--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -44,6 +44,7 @@ HealthCheckInterval={{ slurm_healthcheck_interval }}
 HealthCheckProgram={{ slurm_healthcheck_program }}
 {% endif %}
 GresTypes={{ slurm_grestypes }}
+MailProg=/usr/bin/smail
 
 # TIMERS
 SlurmctldTimeout={{ slurm_SlurmctldTimeout }}


### PR DESCRIPTION
The seff script is a simple script which checks the CPU and memory
usage vs. allocated. smail is a small wrapper around /bin/mail which
adds the seff output to the body of the notification emails that slurm
sends (by default the body is empty). Both scripts are part of the
slurm-seff package.

See https://bugs.schedmd.com/show_bug.cgi?id=1611